### PR TITLE
geom_alt props

### DIFF
--- a/data/421/173/329/421173329.geojson
+++ b/data/421/173/329/421173329.geojson
@@ -107,6 +107,9 @@
     },
     "wof:country":"SZ",
     "wof:created":1459008979,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b902c9d3af91e48d5cde3edafe46af8d",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":421173329,
-    "wof:lastmodified":1566652652,
+    "wof:lastmodified":1582347814,
     "wof:name":"Kwaluseni",
     "wof:parent_id":85678219,
     "wof:placetype":"county",

--- a/data/421/175/617/421175617.geojson
+++ b/data/421/175/617/421175617.geojson
@@ -87,6 +87,9 @@
     },
     "wof:country":"SZ",
     "wof:created":1459009073,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b8eeea7353e4bbc5686d112943d6e72c",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
         }
     ],
     "wof:id":421175617,
-    "wof:lastmodified":1566652652,
+    "wof:lastmodified":1582347814,
     "wof:name":"Nkaba",
     "wof:parent_id":85678211,
     "wof:placetype":"county",

--- a/data/421/175/623/421175623.geojson
+++ b/data/421/175/623/421175623.geojson
@@ -101,6 +101,9 @@
     },
     "wof:country":"SZ",
     "wof:created":1459009073,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c304af711869d5e53f616021535a6fdd",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
         }
     ],
     "wof:id":421175623,
-    "wof:lastmodified":1566652653,
+    "wof:lastmodified":1582347814,
     "wof:name":"Lomahasha",
     "wof:parent_id":85678215,
     "wof:placetype":"county",

--- a/data/421/175/625/421175625.geojson
+++ b/data/421/175/625/421175625.geojson
@@ -106,6 +106,9 @@
     },
     "wof:country":"SZ",
     "wof:created":1459009073,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"633f9474509e6f4f0936ed14add727a6",
     "wof:hierarchy":[
         {
@@ -116,7 +119,7 @@
         }
     ],
     "wof:id":421175625,
-    "wof:lastmodified":1566652653,
+    "wof:lastmodified":1582347814,
     "wof:name":"Manzini",
     "wof:parent_id":85678219,
     "wof:placetype":"county",

--- a/data/421/175/627/421175627.geojson
+++ b/data/421/175/627/421175627.geojson
@@ -123,6 +123,9 @@
     },
     "wof:country":"SZ",
     "wof:created":1459009073,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0e51cec3dac63199fd3ed8c6a72f6220",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":421175627,
-    "wof:lastmodified":1566652653,
+    "wof:lastmodified":1582347814,
     "wof:name":"Mhlume",
     "wof:parent_id":85678215,
     "wof:placetype":"county",

--- a/data/421/178/537/421178537.geojson
+++ b/data/421/178/537/421178537.geojson
@@ -326,6 +326,9 @@
     },
     "wof:country":"SZ",
     "wof:created":1459009185,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4bdb86642f9a2ad878aec972077f7f68",
     "wof:hierarchy":[
         {
@@ -336,7 +339,7 @@
         }
     ],
     "wof:id":421178537,
-    "wof:lastmodified":1566652654,
+    "wof:lastmodified":1582347814,
     "wof:name":"Lobamba",
     "wof:parent_id":85678211,
     "wof:placetype":"county",

--- a/data/421/183/019/421183019.geojson
+++ b/data/421/183/019/421183019.geojson
@@ -108,6 +108,9 @@
     },
     "wof:country":"SZ",
     "wof:created":1459009355,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b5ef37ce85d6be0dccc0a8458b6a1d67",
     "wof:hierarchy":[
         {
@@ -118,7 +121,7 @@
         }
     ],
     "wof:id":421183019,
-    "wof:lastmodified":1566652654,
+    "wof:lastmodified":1582347814,
     "wof:name":"Siphofaneni",
     "wof:parent_id":85678215,
     "wof:placetype":"county",

--- a/data/421/183/335/421183335.geojson
+++ b/data/421/183/335/421183335.geojson
@@ -101,6 +101,9 @@
     },
     "wof:country":"SZ",
     "wof:created":1459009366,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cd42f6565f08b6369c6e24f70bfb4180",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
         }
     ],
     "wof:id":421183335,
-    "wof:lastmodified":1566652654,
+    "wof:lastmodified":1582347814,
     "wof:name":"Ntfonjeni",
     "wof:parent_id":85678211,
     "wof:placetype":"county",

--- a/data/421/186/543/421186543.geojson
+++ b/data/421/186/543/421186543.geojson
@@ -101,6 +101,9 @@
     },
     "wof:country":"SZ",
     "wof:created":1459009484,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9e625eb18891ea1e43b60211e54700cd",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
         }
     ],
     "wof:id":421186543,
-    "wof:lastmodified":1566652652,
+    "wof:lastmodified":1582347814,
     "wof:name":"Hlane",
     "wof:parent_id":85678215,
     "wof:placetype":"county",

--- a/data/421/191/941/421191941.geojson
+++ b/data/421/191/941/421191941.geojson
@@ -99,6 +99,9 @@
     },
     "wof:country":"SZ",
     "wof:created":1459009715,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"64e56352224c1a29bde0121dafda7fa4",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
         }
     ],
     "wof:id":421191941,
-    "wof:lastmodified":1566652653,
+    "wof:lastmodified":1582347814,
     "wof:name":"Motjane",
     "wof:parent_id":85678211,
     "wof:placetype":"county",

--- a/data/421/195/839/421195839.geojson
+++ b/data/421/195/839/421195839.geojson
@@ -121,6 +121,9 @@
     },
     "wof:country":"SZ",
     "wof:created":1459009861,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"65b53f0f53b3307df21bf56e31cf31c0",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
         }
     ],
     "wof:id":421195839,
-    "wof:lastmodified":1566652649,
+    "wof:lastmodified":1582347813,
     "wof:name":"Lavumisa",
     "wof:parent_id":85678223,
     "wof:placetype":"county",

--- a/data/421/199/783/421199783.geojson
+++ b/data/421/199/783/421199783.geojson
@@ -396,6 +396,9 @@
     },
     "wof:country":"SZ",
     "wof:created":1459010000,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4bdb86642f9a2ad878aec972077f7f68",
     "wof:hierarchy":[
         {
@@ -407,7 +410,7 @@
         }
     ],
     "wof:id":421199783,
-    "wof:lastmodified":1566652653,
+    "wof:lastmodified":1582347814,
     "wof:name":"Lobamba",
     "wof:parent_id":421178537,
     "wof:placetype":"locality",

--- a/data/421/202/643/421202643.geojson
+++ b/data/421/202/643/421202643.geojson
@@ -101,6 +101,9 @@
     },
     "wof:country":"SZ",
     "wof:created":1459010125,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"803121e3db303b1f95490f130eef4b63",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
         }
     ],
     "wof:id":421202643,
-    "wof:lastmodified":1566652651,
+    "wof:lastmodified":1582347813,
     "wof:name":"Lubuli",
     "wof:parent_id":85678215,
     "wof:placetype":"county",

--- a/data/421/202/649/421202649.geojson
+++ b/data/421/202/649/421202649.geojson
@@ -140,6 +140,9 @@
     },
     "wof:country":"SZ",
     "wof:created":1459010125,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1f2e613012cadde9470906b898c24498",
     "wof:hierarchy":[
         {
@@ -150,7 +153,7 @@
         }
     ],
     "wof:id":421202649,
-    "wof:lastmodified":1566652651,
+    "wof:lastmodified":1582347814,
     "wof:name":"Pigg's Peak",
     "wof:parent_id":85678211,
     "wof:placetype":"county",

--- a/data/421/202/651/421202651.geojson
+++ b/data/421/202/651/421202651.geojson
@@ -443,6 +443,9 @@
     },
     "wof:country":"SZ",
     "wof:created":1459010125,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"043af2b1771900d79dbfd2811b2f2269",
     "wof:hierarchy":[
         {
@@ -453,7 +456,7 @@
         }
     ],
     "wof:id":421202651,
-    "wof:lastmodified":1566652651,
+    "wof:lastmodified":1582347813,
     "wof:name":"Mbabane",
     "wof:parent_id":85678211,
     "wof:placetype":"county",

--- a/data/421/203/091/421203091.geojson
+++ b/data/421/203/091/421203091.geojson
@@ -538,6 +538,9 @@
     },
     "wof:country":"SZ",
     "wof:created":1459010140,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"043af2b1771900d79dbfd2811b2f2269",
     "wof:hierarchy":[
         {
@@ -549,7 +552,7 @@
         }
     ],
     "wof:id":421203091,
-    "wof:lastmodified":1566652650,
+    "wof:lastmodified":1582347813,
     "wof:name":"Mbabane",
     "wof:parent_id":421202651,
     "wof:placetype":"locality",

--- a/data/856/326/35/85632635.geojson
+++ b/data/856/326/35/85632635.geojson
@@ -1006,6 +1006,7 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "naturalearth",
+        "naturalearth",
         "meso"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -1061,6 +1062,11 @@
     },
     "wof:country":"SZ",
     "wof:country_alpha3":"SWZ",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth",
+        "meso"
+    ],
     "wof:geomhash":"267ca3a54028b98d5712c3a065baa4fc",
     "wof:hierarchy":[
         {
@@ -1077,7 +1083,7 @@
         "eng",
         "ssw"
     ],
-    "wof:lastmodified":1566652634,
+    "wof:lastmodified":1582347813,
     "wof:name":"eSwatini",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/326/35/85632635.geojson
+++ b/data/856/326/35/85632635.geojson
@@ -1006,7 +1006,6 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "naturalearth",
-        "naturalearth",
         "meso"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -1083,7 +1082,7 @@
         "eng",
         "ssw"
     ],
-    "wof:lastmodified":1582347813,
+    "wof:lastmodified":1583227712,
     "wof:name":"eSwatini",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/782/11/85678211.geojson
+++ b/data/856/782/11/85678211.geojson
@@ -285,6 +285,9 @@
         "wk:page":"Hhohho Region"
     },
     "wof:country":"SZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"129680c878ad961af212396e500ff89e",
     "wof:hierarchy":[
         {
@@ -302,7 +305,7 @@
         "eng",
         "ssw"
     ],
-    "wof:lastmodified":1566652633,
+    "wof:lastmodified":1582347813,
     "wof:name":"Hhohho",
     "wof:parent_id":85632635,
     "wof:placetype":"region",

--- a/data/856/782/15/85678215.geojson
+++ b/data/856/782/15/85678215.geojson
@@ -270,6 +270,9 @@
         "wk:page":"Lubombo Region"
     },
     "wof:country":"SZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b76bdc35180cc6897dd1c513a7d07ea5",
     "wof:hierarchy":[
         {
@@ -287,7 +290,7 @@
         "eng",
         "ssw"
     ],
-    "wof:lastmodified":1566652634,
+    "wof:lastmodified":1582347813,
     "wof:name":"Lubombo",
     "wof:parent_id":85632635,
     "wof:placetype":"region",

--- a/data/856/782/19/85678219.geojson
+++ b/data/856/782/19/85678219.geojson
@@ -267,6 +267,9 @@
         "wk:page":"Manzini Region"
     },
     "wof:country":"SZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"58c2f38f548d415a3d754c82e73f1c8f",
     "wof:hierarchy":[
         {
@@ -284,7 +287,7 @@
         "eng",
         "ssw"
     ],
-    "wof:lastmodified":1566652634,
+    "wof:lastmodified":1582347813,
     "wof:name":"Manzini",
     "wof:parent_id":85632635,
     "wof:placetype":"region",

--- a/data/856/782/23/85678223.geojson
+++ b/data/856/782/23/85678223.geojson
@@ -270,6 +270,9 @@
         "wk:page":"Shiselweni Region"
     },
     "wof:country":"SZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e10e30d1418b8d888203248b518cf874",
     "wof:hierarchy":[
         {
@@ -287,7 +290,7 @@
         "eng",
         "ssw"
     ],
-    "wof:lastmodified":1566652634,
+    "wof:lastmodified":1582347813,
     "wof:name":"Shiselweni",
     "wof:parent_id":85632635,
     "wof:placetype":"region",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.