### PR TITLE
sz concordances, placetype local, and more

### DIFF
--- a/data/110/856/120/7/1108561207.geojson
+++ b/data/110/856/120/7/1108561207.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016287,
-    "geom:area_square_m":181228760.322894,
+    "geom:area_square_m":181228570.879611,
     "geom:bbox":"31.451313,-25.937484,31.586466,-25.769083",
     "geom:latitude":-25.861094,
     "geom:longitude":31.520056,
@@ -70,9 +70,10 @@
     "wof:concordances":{
         "hasc:id":"SZ.HH.MY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SZ",
     "wof:created":1473982885,
-    "wof:geomhash":"e3b5a983c3e51ce0f1377e68678d72c3",
+    "wof:geomhash":"e483b82ef0f3a47a0680b757c44243a2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -82,7 +83,7 @@
         }
     ],
     "wof:id":1108561207,
-    "wof:lastmodified":1627522809,
+    "wof:lastmodified":1695886510,
     "wof:name":"Mayiwane",
     "wof:parent_id":85678211,
     "wof:placetype":"county",

--- a/data/110/856/120/9/1108561209.geojson
+++ b/data/110/856/120/9/1108561209.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02442,
-    "geom:area_square_m":271530732.503107,
+    "geom:area_square_m":271530866.217015,
     "geom:bbox":"31.515191,-26.055601,31.76541,-25.824264",
     "geom:latitude":-25.944546,
     "geom:longitude":31.629238,
@@ -73,9 +73,10 @@
     "wof:concordances":{
         "hasc:id":"SZ.HH.MH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SZ",
     "wof:created":1473982887,
-    "wof:geomhash":"70406c737a21017767c51bbaad609120",
+    "wof:geomhash":"15539a4303aec36b14a97767b52bbc5e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108561209,
-    "wof:lastmodified":1627522809,
+    "wof:lastmodified":1695886510,
     "wof:name":"Mhlangatane",
     "wof:parent_id":85678211,
     "wof:placetype":"county",

--- a/data/110/856/121/1/1108561211.geojson
+++ b/data/110/856/121/1/1108561211.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019746,
-    "geom:area_square_m":217179702.357811,
+    "geom:area_square_m":217179433.364896,
     "geom:bbox":"31.235986,-27.278633,31.405901,-27.093069",
     "geom:latitude":-27.188977,
     "geom:longitude":31.331431,
@@ -76,9 +76,10 @@
     "wof:concordances":{
         "hasc:id":"SZ.SH.ZO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SZ",
     "wof:created":1473982888,
-    "wof:geomhash":"e96b307b51e5c54682ff6d94147d37b4",
+    "wof:geomhash":"37e06329871e2e82ae956100dcefb4bb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108561211,
-    "wof:lastmodified":1627522810,
+    "wof:lastmodified":1695886511,
     "wof:name":"Zombodze",
     "wof:parent_id":85678223,
     "wof:placetype":"county",

--- a/data/110/856/121/3/1108561213.geojson
+++ b/data/110/856/121/3/1108561213.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016071,
-    "geom:area_square_m":178002163.329812,
+    "geom:area_square_m":178001795.560202,
     "geom:bbox":"31.248676,-26.501388,31.379885,-26.289293",
     "geom:latitude":-26.398408,
     "geom:longitude":31.314285,
@@ -70,9 +70,10 @@
     "wof:concordances":{
         "hasc:id":"SZ.MA.LZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SZ",
     "wof:created":1473982891,
-    "wof:geomhash":"48155468c79d4e71e50ac83d2fa7bcc0",
+    "wof:geomhash":"caa086b13e3c59537eb01bc2bbe900c9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -82,7 +83,7 @@
         }
     ],
     "wof:id":1108561213,
-    "wof:lastmodified":1627522808,
+    "wof:lastmodified":1695886508,
     "wof:name":"Ludzeludze",
     "wof:parent_id":85678219,
     "wof:placetype":"county",

--- a/data/110/856/121/5/1108561215.geojson
+++ b/data/110/856/121/5/1108561215.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013848,
-    "geom:area_square_m":153203373.393401,
+    "geom:area_square_m":153203502.963327,
     "geom:bbox":"31.14525,-26.592927,31.292219,-26.451832",
     "geom:latitude":-26.52928,
     "geom:longitude":31.216698,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"SZ.MA.LL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SZ",
     "wof:created":1473982893,
-    "wof:geomhash":"29f735bd8f9bf44ae68f193b721bdae4",
+    "wof:geomhash":"a4573207a08834d6773fc4c713adcdbe",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108561215,
-    "wof:lastmodified":1627522808,
+    "wof:lastmodified":1695886509,
     "wof:name":"Mahlanya",
     "wof:parent_id":85678219,
     "wof:placetype":"county",

--- a/data/110/856/121/7/1108561217.geojson
+++ b/data/110/856/121/7/1108561217.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010844,
-    "geom:area_square_m":119932509.900741,
+    "geom:area_square_m":119932804.918154,
     "geom:bbox":"30.983472,-26.625965,31.162066,-26.500085",
     "geom:latitude":-26.56778,
     "geom:longitude":31.071296,
@@ -76,9 +76,10 @@
     "wof:concordances":{
         "hasc:id":"SZ.MA.LA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SZ",
     "wof:created":1473982894,
-    "wof:geomhash":"b65578246a4424cddb3984cfae2705e8",
+    "wof:geomhash":"c5e3d9cd2cc373de33b77cad8180f759",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108561217,
-    "wof:lastmodified":1627522808,
+    "wof:lastmodified":1695886509,
     "wof:name":"Lamgabhi",
     "wof:parent_id":85678219,
     "wof:placetype":"county",

--- a/data/110/856/121/9/1108561219.geojson
+++ b/data/110/856/121/9/1108561219.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.021177,
-    "geom:area_square_m":234564598.017448,
+    "geom:area_square_m":234564680.974559,
     "geom:bbox":"31.338267,-26.485157,31.524617,-26.284878",
     "geom:latitude":-26.389957,
     "geom:longitude":31.421101,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"SZ.MA.EK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SZ",
     "wof:created":1473982897,
-    "wof:geomhash":"67f21dd5017fc182e16560185ef35dcf",
+    "wof:geomhash":"e7b74d27066d5f96d91cbeffbd17b595",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108561219,
-    "wof:lastmodified":1627522808,
+    "wof:lastmodified":1695886509,
     "wof:name":"Kukhanyeni",
     "wof:parent_id":85678219,
     "wof:placetype":"county",

--- a/data/110/856/122/3/1108561223.geojson
+++ b/data/110/856/122/3/1108561223.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.050391,
-    "geom:area_square_m":559086207.062697,
+    "geom:area_square_m":559086625.249236,
     "geom:bbox":"31.192885,-26.324309,31.545405,-26.076301",
     "geom:latitude":-26.198956,
     "geom:longitude":31.361564,
@@ -70,9 +70,10 @@
     "wof:concordances":{
         "hasc:id":"SZ.HH.ML"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SZ",
     "wof:created":1473982898,
-    "wof:geomhash":"1b567ff0a44e0f7ceaaa958ae4d03945",
+    "wof:geomhash":"fd056cd1b47a905353bab6a31d09499b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -82,7 +83,7 @@
         }
     ],
     "wof:id":1108561223,
-    "wof:lastmodified":1627522809,
+    "wof:lastmodified":1695886510,
     "wof:name":"Maphalaleni",
     "wof:parent_id":85678211,
     "wof:placetype":"county",

--- a/data/110/856/122/5/1108561225.geojson
+++ b/data/110/856/122/5/1108561225.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.037836,
-    "geom:area_square_m":419517447.720846,
+    "geom:area_square_m":419517407.465237,
     "geom:bbox":"31.422945,-26.387863,31.699783,-26.161949",
     "geom:latitude":-26.274708,
     "geom:longitude":31.578636,
@@ -70,9 +70,10 @@
     "wof:concordances":{
         "hasc:id":"SZ.MA.MK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SZ",
     "wof:created":1473982903,
-    "wof:geomhash":"925005bbf58425dbac5c6aeacfe133d9",
+    "wof:geomhash":"67328db0ae0bcfe603d9d1ed65959235",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -82,7 +83,7 @@
         }
     ],
     "wof:id":1108561225,
-    "wof:lastmodified":1627522809,
+    "wof:lastmodified":1695886510,
     "wof:name":"Mkhiweni",
     "wof:parent_id":85678219,
     "wof:placetype":"county",

--- a/data/110/856/122/7/1108561227.geojson
+++ b/data/110/856/122/7/1108561227.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.027252,
-    "geom:area_square_m":299814550.088631,
+    "geom:area_square_m":299814550.088609,
     "geom:bbox":"31.3857330589,-27.2484430082,31.6681552936,-27.0858157617",
     "geom:latitude":-27.16121,
     "geom:longitude":31.5278,
@@ -163,9 +163,10 @@
     "wof:concordances":{
         "hasc:id":"SZ.SH.HO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SZ",
     "wof:created":1473982904,
-    "wof:geomhash":"142f1d34a1940d8a6be9c40b333d2a1a",
+    "wof:geomhash":"3d3150cfe99e2a08584b5ed4c4151243",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -175,7 +176,7 @@
         }
     ],
     "wof:id":1108561227,
-    "wof:lastmodified":1566652646,
+    "wof:lastmodified":1695886442,
     "wof:name":"Hosea",
     "wof:parent_id":85678223,
     "wof:placetype":"county",

--- a/data/110/856/122/9/1108561229.geojson
+++ b/data/110/856/122/9/1108561229.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012413,
-    "geom:area_square_m":136708484.676482,
+    "geom:area_square_m":136708519.548993,
     "geom:bbox":"31.483926,-27.105829,31.617845,-26.96721",
     "geom:latitude":-27.038082,
     "geom:longitude":31.552455,
@@ -73,9 +73,10 @@
     "wof:concordances":{
         "hasc:id":"SZ.SH.NG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SZ",
     "wof:created":1473982906,
-    "wof:geomhash":"3529ddb01d828f0a2aeeb491d7c47022",
+    "wof:geomhash":"f7e7b48d03723e23ea9759b917a68cab",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108561229,
-    "wof:lastmodified":1627522809,
+    "wof:lastmodified":1695886510,
     "wof:name":"Ngudzeni",
     "wof:parent_id":85678223,
     "wof:placetype":"county",

--- a/data/110/856/123/1/1108561231.geojson
+++ b/data/110/856/123/1/1108561231.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.053034,
-    "geom:area_square_m":585756894.567799,
+    "geom:area_square_m":585756616.738595,
     "geom:bbox":"30.790656,-26.844394,31.291215,-26.61683",
     "geom:latitude":-26.718631,
     "geom:longitude":31.00457,
@@ -70,9 +70,10 @@
     "wof:concordances":{
         "hasc:id":"SZ.MA.NP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SZ",
     "wof:created":1473982907,
-    "wof:geomhash":"d950398a700bc6f827442f1c353eb3f1",
+    "wof:geomhash":"22cc0af9c33b4369250df9b95ce74988",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -82,7 +83,7 @@
         }
     ],
     "wof:id":1108561231,
-    "wof:lastmodified":1627522809,
+    "wof:lastmodified":1695886510,
     "wof:name":"Ngwempisi",
     "wof:parent_id":85678219,
     "wof:placetype":"county",

--- a/data/110/856/123/3/1108561233.geojson
+++ b/data/110/856/123/3/1108561233.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02049,
-    "geom:area_square_m":226082374.320565,
+    "geom:area_square_m":226082583.822287,
     "geom:bbox":"31.362372,-26.910257,31.552974,-26.755226",
     "geom:latitude":-26.831385,
     "geom:longitude":31.454444,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SZ.SH.KU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SZ",
     "wof:created":1473982909,
-    "wof:geomhash":"bf37940a768478a1cd2a1f37955c036b",
+    "wof:geomhash":"0f6757f0e0961acb120de5ca5a998d1c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108561233,
-    "wof:lastmodified":1627522808,
+    "wof:lastmodified":1695886509,
     "wof:name":"Kubuta",
     "wof:parent_id":85678223,
     "wof:placetype":"county",

--- a/data/110/856/123/5/1108561235.geojson
+++ b/data/110/856/123/5/1108561235.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019818,
-    "geom:area_square_m":219062680.087351,
+    "geom:area_square_m":219062726.211315,
     "geom:bbox":"31.284666,-26.767288,31.512025,-26.519896",
     "geom:latitude":-26.62675,
     "geom:longitude":31.400632,
@@ -76,9 +76,10 @@
     "wof:concordances":{
         "hasc:id":"SZ.MA.NH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SZ",
     "wof:created":1473982910,
-    "wof:geomhash":"04c66417eb76571192e0ed160b1bfb32",
+    "wof:geomhash":"1ba445f1bc64ff51c4b17b3aeec33a6e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108561235,
-    "wof:lastmodified":1627522809,
+    "wof:lastmodified":1695886510,
     "wof:name":"Nhlambeni",
     "wof:parent_id":85678219,
     "wof:placetype":"county",

--- a/data/110/856/123/7/1108561237.geojson
+++ b/data/110/856/123/7/1108561237.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.031489,
-    "geom:area_square_m":349918291.082937,
+    "geom:area_square_m":349918350.562827,
     "geom:bbox":"31.309451,-26.118845,31.548946,-25.911626",
     "geom:latitude":-26.016009,
     "geom:longitude":31.4434,
@@ -73,9 +73,10 @@
     "wof:concordances":{
         "hasc:id":"SZ.HH.ND"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SZ",
     "wof:created":1473982912,
-    "wof:geomhash":"150680d8551c8c0a073c82f6b9603fd9",
+    "wof:geomhash":"526818c86ee21bfa21bedbe954c418d3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108561237,
-    "wof:lastmodified":1627522809,
+    "wof:lastmodified":1695886510,
     "wof:name":"Ndzingeni",
     "wof:parent_id":85678211,
     "wof:placetype":"county",

--- a/data/110/856/124/1/1108561241.geojson
+++ b/data/110/856/124/1/1108561241.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.043166,
-    "geom:area_square_m":476281372.980107,
+    "geom:area_square_m":476281331.957587,
     "geom:bbox":"31.737748,-26.966864,32.019771,-26.679081",
     "geom:latitude":-26.833245,
     "geom:longitude":31.906503,
@@ -70,9 +70,10 @@
     "wof:concordances":{
         "hasc:id":"SZ.LU.NK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SZ",
     "wof:created":1473982917,
-    "wof:geomhash":"8b32639019ea56665c5e5c698e16d646",
+    "wof:geomhash":"478e5e51b84f6c78a2bb739e90285f47",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -82,7 +83,7 @@
         }
     ],
     "wof:id":1108561241,
-    "wof:lastmodified":1627522810,
+    "wof:lastmodified":1695886511,
     "wof:name":"Nkilongo",
     "wof:parent_id":85678215,
     "wof:placetype":"county",

--- a/data/110/856/124/3/1108561243.geojson
+++ b/data/110/856/124/3/1108561243.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.024888,
-    "geom:area_square_m":274301580.74755,
+    "geom:area_square_m":274301260.467109,
     "geom:bbox":"31.253253,-27.041917,31.531577,-26.885502",
     "geom:latitude":-26.959413,
     "geom:longitude":31.385588,
@@ -73,9 +73,10 @@
     "wof:concordances":{
         "hasc:id":"SZ.SH.MS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SZ",
     "wof:created":1473982918,
-    "wof:geomhash":"6b859a1ea4c65f02d796601d0d5d6eeb",
+    "wof:geomhash":"015d49e4ea3adf5b4a6ba36e87beb090",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108561243,
-    "wof:lastmodified":1627522809,
+    "wof:lastmodified":1695886510,
     "wof:name":"Mtsambama",
     "wof:parent_id":85678223,
     "wof:placetype":"county",

--- a/data/110/856/124/5/1108561245.geojson
+++ b/data/110/856/124/5/1108561245.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.060356,
-    "geom:area_square_m":665736303.267895,
+    "geom:area_square_m":665736439.246924,
     "geom:bbox":"31.488183,-27.041796,31.839488,-26.731139",
     "geom:latitude":-26.869589,
     "geom:longitude":31.659445,
@@ -73,9 +73,10 @@
     "wof:concordances":{
         "hasc:id":"SZ.LU.SB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SZ",
     "wof:created":1473982919,
-    "wof:geomhash":"6d23e613a97b6122b01683e2b3b42487",
+    "wof:geomhash":"11adb728a3b3462b0643e683b6ef691b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108561245,
-    "wof:lastmodified":1627522810,
+    "wof:lastmodified":1695886511,
     "wof:name":"Sithobela",
     "wof:parent_id":85678215,
     "wof:placetype":"county",

--- a/data/110/856/124/7/1108561247.geojson
+++ b/data/110/856/124/7/1108561247.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.044188,
-    "geom:area_square_m":488401473.741121,
+    "geom:area_square_m":488400041.506431,
     "geom:bbox":"31.948074,-26.840385,32.134844,-26.463693",
     "geom:latitude":-26.637016,
     "geom:longitude":32.066892,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"SZ.LU.MN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SZ",
     "wof:created":1473982922,
-    "wof:geomhash":"d23a95a6113a7f6883d77da02002d23f",
+    "wof:geomhash":"53f84aab0c95402cc1ec6207571172b1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108561247,
-    "wof:lastmodified":1627522810,
+    "wof:lastmodified":1695886511,
     "wof:name":"Tikhuba",
     "wof:parent_id":85678215,
     "wof:placetype":"county",

--- a/data/110/856/124/9/1108561249.geojson
+++ b/data/110/856/124/9/1108561249.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.03742,
-    "geom:area_square_m":413770695.073896,
+    "geom:area_square_m":413770395.510378,
     "geom:bbox":"30.79064,-26.711324,31.037398,-26.440376",
     "geom:latitude":-26.590012,
     "geom:longitude":30.881526,
@@ -73,9 +73,10 @@
     "wof:concordances":{
         "hasc:id":"SZ.MA.MC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SZ",
     "wof:created":1473982925,
-    "wof:geomhash":"f2ccc278ddbfa4b893d2f9aeb4e63206",
+    "wof:geomhash":"1431ae3c82a4d249939916da57664b0f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108561249,
-    "wof:lastmodified":1627522809,
+    "wof:lastmodified":1695886510,
     "wof:name":"Mangcongco",
     "wof:parent_id":85678219,
     "wof:placetype":"county",

--- a/data/110/856/125/1/1108561251.geojson
+++ b/data/110/856/125/1/1108561251.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.037912,
-    "geom:area_square_m":416884629.780814,
+    "geom:area_square_m":416884621.073857,
     "geom:bbox":"31.603862,-27.316891,31.819404,-27.07457",
     "geom:latitude":-27.216195,
     "geom:longitude":31.724251,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"SZ.SH.MJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SZ",
     "wof:created":1473982926,
-    "wof:geomhash":"86936d3ec1664fa9fdf1f6008d8de9e9",
+    "wof:geomhash":"bb876ab8a52f8900880a13508122b2ed",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108561251,
-    "wof:lastmodified":1627522809,
+    "wof:lastmodified":1695886510,
     "wof:name":"Matsanjeni",
     "wof:parent_id":85678223,
     "wof:placetype":"county",

--- a/data/110/856/125/3/1108561253.geojson
+++ b/data/110/856/125/3/1108561253.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.044284,
-    "geom:area_square_m":490251968.134951,
+    "geom:area_square_m":490251968.134924,
     "geom:bbox":"30.8172195424,-26.567012927,31.1755957585,-26.3204323242",
     "geom:latitude":-26.451926,
     "geom:longitude":30.982749,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SZ.MA.MM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SZ",
     "wof:created":1473982928,
-    "wof:geomhash":"02640593a6c39b10ea05c1c9cd43d1c9",
+    "wof:geomhash":"742969bdeb5167bdc15996fcdd16c9c5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108561253,
-    "wof:lastmodified":1566652646,
+    "wof:lastmodified":1695886442,
     "wof:name":"Mhlambanyatsi",
     "wof:parent_id":85678219,
     "wof:placetype":"county",

--- a/data/110/856/125/5/1108561255.geojson
+++ b/data/110/856/125/5/1108561255.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025203,
-    "geom:area_square_m":277955020.287542,
+    "geom:area_square_m":277955521.205338,
     "geom:bbox":"31.122618,-26.997321,31.375225,-26.799276",
     "geom:latitude":-26.884948,
     "geom:longitude":31.251104,
@@ -76,9 +76,10 @@
     "wof:concordances":{
         "hasc:id":"SZ.SH.NW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SZ",
     "wof:created":1473982930,
-    "wof:geomhash":"e69b19353eccedd4d94f56b7fbc6cd20",
+    "wof:geomhash":"5925b4e74f1750a306e02adb63881099",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108561255,
-    "wof:lastmodified":1627522810,
+    "wof:lastmodified":1695886511,
     "wof:name":"Nkwene",
     "wof:parent_id":85678223,
     "wof:placetype":"county",

--- a/data/110/856/125/9/1108561259.geojson
+++ b/data/110/856/125/9/1108561259.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020423,
-    "geom:area_square_m":224497596.631076,
+    "geom:area_square_m":224497045.368287,
     "geom:bbox":"31.38388,-27.31565,31.610369,-27.15383",
     "geom:latitude":-27.25528,
     "geom:longitude":31.487643,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"SZ.SH.SH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SZ",
     "wof:created":1473982932,
-    "wof:geomhash":"eea47e8dc15c44c67523cc6dbefb0baf",
+    "wof:geomhash":"6c7dc7cba94c4962a88080c7576e26ae",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108561259,
-    "wof:lastmodified":1636501633,
+    "wof:lastmodified":1695886792,
     "wof:name":"Shiselweni",
     "wof:parent_id":85678223,
     "wof:placetype":"county",

--- a/data/110/856/126/1/1108561261.geojson
+++ b/data/110/856/126/1/1108561261.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008128,
-    "geom:area_square_m":90507119.549445,
+    "geom:area_square_m":90507115.665132,
     "geom:bbox":"31.376067,-25.832259,31.496431,-25.71792",
     "geom:latitude":-25.774384,
     "geom:longitude":31.433169,
@@ -70,9 +70,10 @@
     "wof:concordances":{
         "hasc:id":"SZ.HH.TI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SZ",
     "wof:created":1473982933,
-    "wof:geomhash":"e976e942bda09dbb5f15115cfeb16c0c",
+    "wof:geomhash":"16a4af9ad58b1522f5f84d68db74a082",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -82,7 +83,7 @@
         }
     ],
     "wof:id":1108561261,
-    "wof:lastmodified":1627522810,
+    "wof:lastmodified":1695886511,
     "wof:name":"Timpisini",
     "wof:parent_id":85678211,
     "wof:placetype":"county",

--- a/data/110/856/126/3/1108561263.geojson
+++ b/data/110/856/126/3/1108561263.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015071,
-    "geom:area_square_m":167036067.050815,
+    "geom:area_square_m":167035839.696864,
     "geom:bbox":"31.161119,-26.422519,31.287448,-26.215746",
     "geom:latitude":-26.32027,
     "geom:longitude":31.2235,
@@ -73,9 +73,10 @@
     "wof:concordances":{
         "hasc:id":"SZ.HH.HH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SZ",
     "wof:created":1473982934,
-    "wof:geomhash":"a481c0b776a1e094c70f7505b08a8d9d",
+    "wof:geomhash":"f48b0860a575f7a43e2e73b3dd7a9f27",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108561263,
-    "wof:lastmodified":1627522808,
+    "wof:lastmodified":1695886509,
     "wof:name":"Hhukwini",
     "wof:parent_id":85678211,
     "wof:placetype":"county",

--- a/data/110/856/126/5/1108561265.geojson
+++ b/data/110/856/126/5/1108561265.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.021838,
-    "geom:area_square_m":241771298.65381,
+    "geom:area_square_m":241771023.819618,
     "geom:bbox":"31.449049,-26.537869,31.666588,-26.334628",
     "geom:latitude":-26.4467,
     "geom:longitude":31.55131,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"SZ.MA.MF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SZ",
     "wof:created":1473982936,
-    "wof:geomhash":"4743d656a7c7608bd635fa7bb15d7f88",
+    "wof:geomhash":"a9fd9a5963d50f37647529e74a5302a4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108561265,
-    "wof:lastmodified":1627522808,
+    "wof:lastmodified":1695886509,
     "wof:name":"Mafutseni",
     "wof:parent_id":85678219,
     "wof:placetype":"county",

--- a/data/110/856/126/7/1108561267.geojson
+++ b/data/110/856/126/7/1108561267.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.041474,
-    "geom:area_square_m":457868577.551839,
+    "geom:area_square_m":457868675.445175,
     "geom:bbox":"31.046809,-26.879165,31.449456,-26.672845",
     "geom:latitude":-26.768968,
     "geom:longitude":31.245838,
@@ -70,9 +70,10 @@
     "wof:concordances":{
         "hasc:id":"SZ.MA.MG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SZ",
     "wof:created":1473982937,
-    "wof:geomhash":"10c169da6bbdb651bda356e09b9f07af",
+    "wof:geomhash":"7219ffb76a9762542a37d2e1b5b063ee",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -82,7 +83,7 @@
         }
     ],
     "wof:id":1108561267,
-    "wof:lastmodified":1627522808,
+    "wof:lastmodified":1695886509,
     "wof:name":"Mahlangatja",
     "wof:parent_id":85678219,
     "wof:placetype":"county",

--- a/data/110/856/126/9/1108561269.geojson
+++ b/data/110/856/126/9/1108561269.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.024875,
-    "geom:area_square_m":276199629.424485,
+    "geom:area_square_m":276199671.123127,
     "geom:bbox":"31.47634,-26.208293,31.685332,-26.015046",
     "geom:latitude":-26.109879,
     "geom:longitude":31.582845,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"SZ.HH.MD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SZ",
     "wof:created":1473982939,
-    "wof:geomhash":"065a511095097fdcd3c994eb35e3948c",
+    "wof:geomhash":"67a5b39ce7cfbb6c1784364cc0cb8c6f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108561269,
-    "wof:lastmodified":1627522808,
+    "wof:lastmodified":1695886509,
     "wof:name":"Madlangampisi",
     "wof:parent_id":85678211,
     "wof:placetype":"county",

--- a/data/110/856/127/1/1108561271.geojson
+++ b/data/110/856/127/1/1108561271.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.024673,
-    "geom:area_square_m":272833773.575591,
+    "geom:area_square_m":272833701.340423,
     "geom:bbox":"31.385743,-26.676223,31.595744,-26.490898",
     "geom:latitude":-26.581836,
     "geom:longitude":31.497164,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"SZ.MA.MT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SZ",
     "wof:created":1473982940,
-    "wof:geomhash":"c6ca619f05941e5f26a6b9e8c42fe92a",
+    "wof:geomhash":"9a0da7aedd43fb330c5d1cc1e561d957",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108561271,
-    "wof:lastmodified":1627522809,
+    "wof:lastmodified":1695886510,
     "wof:name":"Mthongwaneni",
     "wof:parent_id":85678219,
     "wof:placetype":"county",

--- a/data/110/856/127/3/1108561273.geojson
+++ b/data/110/856/127/3/1108561273.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022696,
-    "geom:area_square_m":250865471.875307,
+    "geom:area_square_m":250865356.138081,
     "geom:bbox":"31.054864,-26.712824,31.394249,-26.56018",
     "geom:latitude":-26.632829,
     "geom:longitude":31.251954,
@@ -70,9 +70,10 @@
     "wof:concordances":{
         "hasc:id":"SZ.MA.NZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SZ",
     "wof:created":1473982942,
-    "wof:geomhash":"ab658bcdba6b706881a2f08f24dc4a3e",
+    "wof:geomhash":"7ecca5a0f5096df8cfab09b12ce99a5e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -82,7 +83,7 @@
         }
     ],
     "wof:id":1108561273,
-    "wof:lastmodified":1627522810,
+    "wof:lastmodified":1695886511,
     "wof:name":"Ntondozi",
     "wof:parent_id":85678219,
     "wof:placetype":"county",

--- a/data/110/856/127/7/1108561277.geojson
+++ b/data/110/856/127/7/1108561277.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01426,
-    "geom:area_square_m":157029282.939298,
+    "geom:area_square_m":157029382.679068,
     "geom:bbox":"31.314613,-27.113594,31.516258,-26.973334",
     "geom:latitude":-27.053341,
     "geom:longitude":31.428905,
@@ -70,9 +70,10 @@
     "wof:concordances":{
         "hasc:id":"SZ.SH.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SZ",
     "wof:created":1473982943,
-    "wof:geomhash":"398159c35d369147bdd6ac73b541a9b5",
+    "wof:geomhash":"c0c3298d5c25303d6f6a61c05dd295a0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -82,7 +83,7 @@
         }
     ],
     "wof:id":1108561277,
-    "wof:lastmodified":1627522810,
+    "wof:lastmodified":1695886511,
     "wof:name":"Sandleni",
     "wof:parent_id":85678223,
     "wof:placetype":"county",

--- a/data/110/856/127/9/1108561279.geojson
+++ b/data/110/856/127/9/1108561279.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016603,
-    "geom:area_square_m":182803614.544975,
+    "geom:area_square_m":182803354.396606,
     "geom:bbox":"31.577397,-27.147647,31.77793,-26.971459",
     "geom:latitude":-27.074523,
     "geom:longitude":31.664205,
@@ -73,9 +73,10 @@
     "wof:concordances":{
         "hasc:id":"SZ.SH.SI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SZ",
     "wof:created":1473982945,
-    "wof:geomhash":"e7a78a7bec023f82842befeef3d3f218",
+    "wof:geomhash":"b295d52dbfe488329054baa8b4936e29",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108561279,
-    "wof:lastmodified":1627522810,
+    "wof:lastmodified":1695886512,
     "wof:name":"Sigwe",
     "wof:parent_id":85678223,
     "wof:placetype":"county",

--- a/data/110/856/128/1/1108561281.geojson
+++ b/data/110/856/128/1/1108561281.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.040866,
-    "geom:area_square_m":452796142.168119,
+    "geom:area_square_m":452796454.375436,
     "geom:bbox":"31.911036,-26.511784,32.105158,-26.171413",
     "geom:latitude":-26.352984,
     "geom:longitude":32.014395,
@@ -73,9 +73,10 @@
     "wof:concordances":{
         "hasc:id":"SZ.LU.LG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SZ",
     "wof:created":1473982947,
-    "wof:geomhash":"57e6706f3080f9df2db1f34f87d97585",
+    "wof:geomhash":"6dd618469662b8efebd6bd98101eaa8d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108561281,
-    "wof:lastmodified":1627522808,
+    "wof:lastmodified":1695886509,
     "wof:name":"Lugongolweni",
     "wof:parent_id":85678215,
     "wof:placetype":"county",

--- a/data/110/856/128/3/1108561283.geojson
+++ b/data/110/856/128/3/1108561283.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.052473,
-    "geom:area_square_m":580947457.89553,
+    "geom:area_square_m":580947036.076442,
     "geom:bbox":"31.574009,-26.567403,31.962531,-26.285132",
     "geom:latitude":-26.444115,
     "geom:longitude":31.774774,
@@ -70,9 +70,10 @@
     "wof:concordances":{
         "hasc:id":"SZ.LU.DV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SZ",
     "wof:created":1473982948,
-    "wof:geomhash":"d56d95a16797df0191dbb0f025cdbd8c",
+    "wof:geomhash":"1aca65db5b933493bb13f26b9231af3a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -82,7 +83,7 @@
         }
     ],
     "wof:id":1108561283,
-    "wof:lastmodified":1627522808,
+    "wof:lastmodified":1695886509,
     "wof:name":"Dvokodvweni",
     "wof:parent_id":85678215,
     "wof:placetype":"county",

--- a/data/110/856/128/5/1108561285.geojson
+++ b/data/110/856/128/5/1108561285.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.024576,
-    "geom:area_square_m":270629864.136966,
+    "geom:area_square_m":270629649.023972,
     "geom:bbox":"31.142492,-27.143191,31.36935,-26.956785",
     "geom:latitude":-27.054417,
     "geom:longitude":31.245841,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"SZ.SH.MB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SZ",
     "wof:created":1473982950,
-    "wof:geomhash":"f1ee2564699c1eec12a373a481dc48e6",
+    "wof:geomhash":"8be1f6304e1f2be420d9a136cd1f63a0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108561285,
-    "wof:lastmodified":1627522809,
+    "wof:lastmodified":1695886510,
     "wof:name":"Mbangweni",
     "wof:parent_id":85678223,
     "wof:placetype":"county",

--- a/data/110/856/128/7/1108561287.geojson
+++ b/data/110/856/128/7/1108561287.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.050122,
-    "geom:area_square_m":552589687.408033,
+    "geom:area_square_m":552589459.217908,
     "geom:bbox":"30.894558,-27.083249,31.208275,-26.77389",
     "geom:latitude":-26.924457,
     "geom:longitude":31.043418,
@@ -73,9 +73,10 @@
     "wof:concordances":{
         "hasc:id":"SZ.SH.GE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SZ",
     "wof:created":1473982951,
-    "wof:geomhash":"03396f52426c8eadc7289ee4e7cd6b50",
+    "wof:geomhash":"76f32bceb7e7f27bc8bc46e31677f161",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108561287,
-    "wof:lastmodified":1627522808,
+    "wof:lastmodified":1695886509,
     "wof:name":"Gege",
     "wof:parent_id":85678223,
     "wof:placetype":"county",

--- a/data/110/856/128/9/1108561289.geojson
+++ b/data/110/856/128/9/1108561289.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019703,
-    "geom:area_square_m":216806296.934108,
+    "geom:area_square_m":216805608.634289,
     "geom:bbox":"31.042573,-27.229799,31.271564,-27.005184",
     "geom:latitude":-27.13307,
     "geom:longitude":31.162673,
@@ -73,9 +73,10 @@
     "wof:concordances":{
         "hasc:id":"SZ.SH.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SZ",
     "wof:created":1473982953,
-    "wof:geomhash":"15dfe6ee3f3fa711f90b9ac590b36a97",
+    "wof:geomhash":"f495220328165eb6ce75d4bcd985a728",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108561289,
-    "wof:lastmodified":1627522809,
+    "wof:lastmodified":1695886510,
     "wof:name":"Maseyisini",
     "wof:parent_id":85678223,
     "wof:placetype":"county",

--- a/data/110/856/129/1/1108561291.geojson
+++ b/data/110/856/129/1/1108561291.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.051802,
-    "geom:area_square_m":572694426.428444,
+    "geom:area_square_m":572694556.132986,
     "geom:bbox":"31.638816,-26.752763,32.020933,-26.417022",
     "geom:latitude":-26.60901,
     "geom:longitude":31.872806,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"SZ.LU.MP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SZ",
     "wof:created":1473982954,
-    "wof:geomhash":"c33671698bc2a42e5094605b54fc37f7",
+    "wof:geomhash":"3de17e756ccdf58a0e24c0f3ba7850a1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108561291,
-    "wof:lastmodified":1627522809,
+    "wof:lastmodified":1695886511,
     "wof:name":"Mpolonjeni",
     "wof:parent_id":85678215,
     "wof:placetype":"county",

--- a/data/421/173/329/421173329.geojson
+++ b/data/421/173/329/421173329.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002496,
-    "geom:area_square_m":27623704.677223,
+    "geom:area_square_m":27623687.581726,
     "geom:bbox":"31.285699,-26.534104,31.353338,-26.479397",
     "geom:latitude":-26.506652,
     "geom:longitude":31.315611,
@@ -114,12 +114,13 @@
         "qs_pg:id":286996,
         "wd:id":"Q3798822"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SZ",
     "wof:created":1459008979,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4de84d9b3e63b334b0d480ea2d64625b",
+    "wof:geomhash":"d7e0b9c8b3a9d000e5204f69998e5939",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":421173329,
-    "wof:lastmodified":1690868438,
+    "wof:lastmodified":1695886508,
     "wof:name":"Kwaluseni",
     "wof:parent_id":85678219,
     "wof:placetype":"county",

--- a/data/421/175/617/421175617.geojson
+++ b/data/421/175/617/421175617.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.037787,
-    "geom:area_square_m":419441902.113504,
+    "geom:area_square_m":419441914.311487,
     "geom:bbox":"31.015545,-26.283048,31.301419,-26.031408",
     "geom:latitude":-26.143082,
     "geom:longitude":31.150434,
@@ -88,12 +88,13 @@
         "hasc:id":"SZ.HH.NB",
         "qs_pg:id":383401
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SZ",
     "wof:created":1459009073,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ae2ee237c0e1cc749b235315df4092c1",
+    "wof:geomhash":"f36918796b2af82f66911b7fb916d3dd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":421175617,
-    "wof:lastmodified":1627522810,
+    "wof:lastmodified":1695886511,
     "wof:name":"Nkaba",
     "wof:parent_id":85678211,
     "wof:placetype":"county",

--- a/data/421/175/623/421175623.geojson
+++ b/data/421/175/623/421175623.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02816,
-    "geom:area_square_m":312795898.84201,
+    "geom:area_square_m":312795996.162505,
     "geom:bbox":"31.878689,-26.186854,32.103061,-25.952684",
     "geom:latitude":-26.062894,
     "geom:longitude":32.005164,
@@ -111,12 +111,13 @@
         "qs_pg:id":383403,
         "wd:id":"Q576512"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SZ",
     "wof:created":1459009073,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"deb9732f50295afefc6776bb198b6467",
+    "wof:geomhash":"624a844eb5a6a1247016b8264e9c9d42",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":421175623,
-    "wof:lastmodified":1690868438,
+    "wof:lastmodified":1695886508,
     "wof:name":"Lomahasha",
     "wof:parent_id":85678215,
     "wof:placetype":"county",

--- a/data/421/175/625/421175625.geojson
+++ b/data/421/175/625/421175625.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004043,
-    "geom:area_square_m":44741453.869141,
+    "geom:area_square_m":44741453.869137,
     "geom:bbox":"31.334952062,-26.5490452758,31.4532463773,-26.4693563218",
     "geom:latitude":-26.4995,
     "geom:longitude":31.385558,
@@ -104,12 +104,13 @@
         "hasc:id":"SZ.MA.MZ",
         "qs_pg:id":383404
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SZ",
     "wof:created":1459009073,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"633f9474509e6f4f0936ed14add727a6",
+    "wof:geomhash":"6c9ed014de35535b054c7a926fe1bd91",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":421175625,
-    "wof:lastmodified":1582347814,
+    "wof:lastmodified":1695886791,
     "wof:name":"Manzini",
     "wof:parent_id":85678219,
     "wof:placetype":"county",

--- a/data/421/175/627/421175627.geojson
+++ b/data/421/175/627/421175627.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.068198,
-    "geom:area_square_m":757271422.291134,
+    "geom:area_square_m":757271422.291179,
     "geom:bbox":"31.6682207749,-26.2778962175,32.0325203754,-25.9356641516",
     "geom:latitude":-26.10211,
     "geom:longitude":31.824372,
@@ -121,12 +121,13 @@
         "hasc:id":"SZ.LU.MU",
         "qs_pg:id":383405
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SZ",
     "wof:created":1459009073,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0e51cec3dac63199fd3ed8c6a72f6220",
+    "wof:geomhash":"4006ddde9ea162e4c049ddda1e8bfe99",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":421175627,
-    "wof:lastmodified":1582347814,
+    "wof:lastmodified":1695886791,
     "wof:name":"Mhlume",
     "wof:parent_id":85678215,
     "wof:placetype":"county",

--- a/data/421/178/537/421178537.geojson
+++ b/data/421/178/537/421178537.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010858,
-    "geom:area_square_m":120239071.246472,
+    "geom:area_square_m":120239071.246478,
     "geom:bbox":"31.112436,-26.480578,31.258327,-26.368814",
     "geom:latitude":-26.422422,
     "geom:longitude":31.185058,
@@ -363,6 +363,7 @@
         "qs_pg:id":127930,
         "wd:id":"Q101418"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         421199783
     ],
@@ -371,7 +372,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"403a3e8cc501a9c6848c592f0dd50c28",
+    "wof:geomhash":"6649a6dc44c4568ddd8bfe7bcdd2cedf",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -381,7 +382,7 @@
         }
     ],
     "wof:id":421178537,
-    "wof:lastmodified":1690868440,
+    "wof:lastmodified":1695886792,
     "wof:name":"Lobamba",
     "wof:parent_id":85678211,
     "wof:placetype":"county",

--- a/data/421/183/019/421183019.geojson
+++ b/data/421/183/019/421183019.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.047684,
-    "geom:area_square_m":526834030.382973,
+    "geom:area_square_m":526833816.083127,
     "geom:bbox":"31.478642,-26.780736,31.849965,-26.547025",
     "geom:latitude":-26.683012,
     "geom:longitude":31.658319,
@@ -112,12 +112,13 @@
         "qs_pg:id":959170,
         "wd:id":"Q637090"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SZ",
     "wof:created":1459009355,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ae234284657f4e7162e06ebd18a63ecc",
+    "wof:geomhash":"11e8a1aec4126e2fd75bd8fcd879f6c5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -127,7 +128,7 @@
         }
     ],
     "wof:id":421183019,
-    "wof:lastmodified":1690868439,
+    "wof:lastmodified":1695886791,
     "wof:name":"Siphofaneni",
     "wof:parent_id":85678215,
     "wof:placetype":"county",

--- a/data/421/183/335/421183335.geojson
+++ b/data/421/183/335/421183335.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.027399,
-    "geom:area_square_m":304931834.299578,
+    "geom:area_square_m":304931919.408698,
     "geom:bbox":"31.186742,-25.919865,31.46079,-25.727709",
     "geom:latitude":-25.836947,
     "geom:longitude":31.341729,
@@ -105,12 +105,13 @@
         "qs_pg:id":973275,
         "wd:id":"Q3798856"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SZ",
     "wof:created":1459009366,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f31581c6b6e3fb240ef2d6f3901507ee",
+    "wof:geomhash":"98bc4ca88d3d874fdeb329b45bf82927",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -120,7 +121,7 @@
         }
     ],
     "wof:id":421183335,
-    "wof:lastmodified":1690868439,
+    "wof:lastmodified":1695886511,
     "wof:name":"Ntfonjeni",
     "wof:parent_id":85678211,
     "wof:placetype":"county",

--- a/data/421/186/543/421186543.geojson
+++ b/data/421/186/543/421186543.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.042202,
-    "geom:area_square_m":467882259.630172,
+    "geom:area_square_m":467883020.666485,
     "geom:bbox":"31.615382,-26.418522,31.945605,-26.141623",
     "geom:latitude":-26.283656,
     "geom:longitude":31.784334,
@@ -117,12 +117,13 @@
         "qs_pg:id":1073358,
         "wd:id":"Q3798820"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SZ",
     "wof:created":1459009484,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ce5e2713e9238b5363e93930f6ffac19",
+    "wof:geomhash":"c180b8362ce1b4137390af78432e9592",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":421186543,
-    "wof:lastmodified":1690868438,
+    "wof:lastmodified":1695886508,
     "wof:name":"Hlane",
     "wof:parent_id":85678215,
     "wof:placetype":"county",

--- a/data/421/191/941/421191941.geojson
+++ b/data/421/191/941/421191941.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029667,
-    "geom:area_square_m":328854925.655445,
+    "geom:area_square_m":328854994.220205,
     "geom:bbox":"30.893196,-26.445991,31.124971,-26.166438",
     "geom:latitude":-26.305511,
     "geom:longitude":31.028263,
@@ -100,12 +100,13 @@
         "qs_pg:id":1164298,
         "wd:id":"Q3798845"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SZ",
     "wof:created":1459009715,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3c476acc8de1bbb7fae0e25ecc1187f5",
+    "wof:geomhash":"2ecce482aaebb486111e7c6483350d4a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":421191941,
-    "wof:lastmodified":1627522809,
+    "wof:lastmodified":1695886509,
     "wof:name":"Motjane",
     "wof:parent_id":85678211,
     "wof:placetype":"county",

--- a/data/421/195/839/421195839.geojson
+++ b/data/421/195/839/421195839.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.028758,
-    "geom:area_square_m":316189761.007838,
+    "geom:area_square_m":316189982.478073,
     "geom:bbox":"31.798752,-27.317396,31.977473,-27.092438",
     "geom:latitude":-27.228923,
     "geom:longitude":31.88687,
@@ -137,12 +137,13 @@
         "qs_pg:id":127926,
         "wd:id":"Q3312840"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SZ",
     "wof:created":1459009861,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4a5f1ce5c6eb0867c304b82d92baebce",
+    "wof:geomhash":"083b3d28e135328d2514279652e709c1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -152,7 +153,7 @@
         }
     ],
     "wof:id":421195839,
-    "wof:lastmodified":1690868435,
+    "wof:lastmodified":1695886791,
     "wof:name":"Lavumisa",
     "wof:parent_id":85678223,
     "wof:placetype":"county",

--- a/data/421/202/643/421202643.geojson
+++ b/data/421/202/643/421202643.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.049613,
-    "geom:area_square_m":546487183.824203,
+    "geom:area_square_m":546487225.450879,
     "geom:bbox":"31.688212,-27.169072,31.994445,-26.906867",
     "geom:latitude":-27.024626,
     "geom:longitude":31.867487,
@@ -102,12 +102,13 @@
         "qs_pg:id":225209,
         "wd:id":"Q3798826"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SZ",
     "wof:created":1459010125,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2bd37d6ffd40f487a6b3bf731fb9a5e4",
+    "wof:geomhash":"c2c837d08ad03aa4cb1e1bedacf35c6a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":421202643,
-    "wof:lastmodified":1690868437,
+    "wof:lastmodified":1695886791,
     "wof:name":"Lubuli",
     "wof:parent_id":85678215,
     "wof:placetype":"county",

--- a/data/421/202/649/421202649.geojson
+++ b/data/421/202/649/421202649.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.044457,
-    "geom:area_square_m":494184847.173984,
+    "geom:area_square_m":494184884.31118,
     "geom:bbox":"31.087332,-26.092543,31.430243,-25.86371",
     "geom:latitude":-25.975154,
     "geom:longitude":31.245733,
@@ -153,12 +153,13 @@
         "qs_pg:id":225212,
         "wd:id":"Q1950487"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SZ",
     "wof:created":1459010125,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c6a1ca2d56713678572e42b0ae6638c8",
+    "wof:geomhash":"4288f234fc3417854e9d6ac8554e7fd1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -168,7 +169,7 @@
         }
     ],
     "wof:id":421202649,
-    "wof:lastmodified":1690868437,
+    "wof:lastmodified":1695886791,
     "wof:name":"Pigg's Peak",
     "wof:parent_id":85678211,
     "wof:placetype":"county",

--- a/data/421/202/651/421202651.geojson
+++ b/data/421/202/651/421202651.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008933,
-    "geom:area_square_m":99004369.411457,
+    "geom:area_square_m":99004356.101623,
     "geom:bbox":"31.067593,-26.380718,31.180804,-26.269833",
     "geom:latitude":-26.326313,
     "geom:longitude":31.127298,
@@ -492,12 +492,13 @@
         "qs_pg:id":225213,
         "wd:id":"Q3904"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SZ",
     "wof:created":1459010125,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8516bc5ecdbe56baf743837f08e8c795",
+    "wof:geomhash":"0a55baaf637bddc9d5758be06f93c9e7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -507,7 +508,7 @@
         }
     ],
     "wof:id":421202651,
-    "wof:lastmodified":1690868437,
+    "wof:lastmodified":1695886791,
     "wof:name":"Mbabane",
     "wof:parent_id":85678211,
     "wof:placetype":"county",

--- a/data/856/326/35/85632635.geojson
+++ b/data/856/326/35/85632635.geojson
@@ -1463,6 +1463,7 @@
         "gp:id":23424993,
         "hasc:id":"SZ",
         "ioc:id":"SWZ",
+        "iso:code":"SZ",
         "itu:id":"SWZ",
         "loc:id":"n81087157",
         "m49:code":"748",
@@ -1477,6 +1478,7 @@
         "wk:page":"Swaziland",
         "wmo:id":"SV"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SZ",
     "wof:country_alpha3":"SWZ",
     "wof:geom_alt":[
@@ -1500,7 +1502,7 @@
         "eng",
         "ssw"
     ],
-    "wof:lastmodified":1694639538,
+    "wof:lastmodified":1695881196,
     "wof:name":"eSwatini",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/782/11/85678211.geojson
+++ b/data/856/782/11/85678211.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.329765,
-    "geom:area_square_m":3662163620.518166,
+    "geom:area_square_m":3662164178.993423,
     "geom:bbox":"30.893196,-26.480578,31.76541,-25.71792",
     "geom:latitude":-26.088061,
     "geom:longitude":31.325576,
@@ -309,16 +309,18 @@
         "gn:id":935085,
         "gp:id":20069889,
         "hasc:id":"SZ.HH",
+        "iso:code":"SZ-HH",
         "iso:id":"SZ-HH",
         "qs_pg:id":429067,
         "wd:id":"Q735570",
         "wk:page":"Hhohho Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9e5a41c9cc91aa44d31764a070bf8120",
+    "wof:geomhash":"af447b1eaee7ec6f9716208a891de934",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -335,7 +337,7 @@
         "eng",
         "ssw"
     ],
-    "wof:lastmodified":1690868433,
+    "wof:lastmodified":1695884899,
     "wof:name":"Hhohho",
     "wof:parent_id":85632635,
     "wof:placetype":"region",

--- a/data/856/782/15/85678215.geojson
+++ b/data/856/782/15/85678215.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.528706,
-    "geom:area_square_m":5848127971.452023,
+    "geom:area_square_m":5848126868.276775,
     "geom:bbox":"31.478642,-27.169072,32.134844,-25.935664",
     "geom:latitude":-26.548483,
     "geom:longitude":31.842533,
@@ -288,16 +288,18 @@
         "gn:id":935042,
         "gp:id":20069891,
         "hasc:id":"SZ.LU",
+        "iso:code":"SZ-LU",
         "iso:id":"SZ-LU",
         "qs_pg:id":202004,
         "wd:id":"Q856657",
         "wk:page":"Lubombo Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8a05e8ea99e86b7974dee6ab96a77d35",
+    "wof:geomhash":"c16c7e85f32fdf597d0ef0931ed376cb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -314,7 +316,7 @@
         "eng",
         "ssw"
     ],
-    "wof:lastmodified":1690868434,
+    "wof:lastmodified":1695884899,
     "wof:name":"Lubombo",
     "wof:parent_id":85632635,
     "wof:placetype":"region",

--- a/data/856/782/19/85678219.geojson
+++ b/data/856/782/19/85678219.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.371553,
-    "geom:area_square_m":4109766610.429075,
+    "geom:area_square_m":4109765929.500698,
     "geom:bbox":"30.79064,-26.879165,31.699783,-26.161949",
     "geom:latitude":-26.551241,
     "geom:longitude":31.229274,
@@ -292,16 +292,18 @@
         "gn:id":934994,
         "gp:id":20069892,
         "hasc:id":"SZ.MA",
+        "iso:code":"SZ-MA",
         "iso:id":"SZ-MA",
         "qs_pg:id":1149778,
         "wd:id":"Q305395",
         "wk:page":"Manzini Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"69894f123e64b4841824f508ab7a4862",
+    "wof:geomhash":"59db0abbb2af021ae8162ac76709a299",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -318,7 +320,7 @@
         "eng",
         "ssw"
     ],
-    "wof:lastmodified":1690868433,
+    "wof:lastmodified":1695884899,
     "wof:name":"Manzini",
     "wof:parent_id":85632635,
     "wof:placetype":"region",

--- a/data/856/782/23/85678223.geojson
+++ b/data/856/782/23/85678223.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.342346,
-    "geom:area_square_m":3769472445.861771,
+    "geom:area_square_m":3769471254.607632,
     "geom:bbox":"30.894558,-27.317396,31.977473,-26.755226",
     "geom:latitude":-27.068342,
     "geom:longitude":31.422116,
@@ -288,16 +288,18 @@
         "gn:id":934867,
         "gp:id":20069890,
         "hasc:id":"SZ.SH",
+        "iso:code":"SZ-SH",
         "iso:id":"SZ-SH",
         "qs_pg:id":43446,
         "wd:id":"Q845934",
         "wk:page":"Shiselweni Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f0d792496761ef76ddd5964a860e960d",
+    "wof:geomhash":"413480d69fd8c714e0aaf0ab3240a65b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -314,7 +316,7 @@
         "eng",
         "ssw"
     ],
-    "wof:lastmodified":1690868433,
+    "wof:lastmodified":1695884899,
     "wof:name":"Shiselweni",
     "wof:parent_id":85632635,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.